### PR TITLE
Fix Postgres nodePort to valid Kubernetes range

### DIFF
--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -9,5 +9,5 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
-      nodePort: 5434
+      nodePort: 30432
   type: NodePort


### PR DESCRIPTION
Fixing Postgres nodePort to valid Kubernetes range